### PR TITLE
Support Lark mini-app

### DIFF
--- a/src/utils/platForm.ts
+++ b/src/utils/platForm.ts
@@ -1,13 +1,19 @@
 import createError from 'axios/lib/core/createError'
 import { AxiosResponse, AxiosRequestConfig } from 'axios'
 
-let platFormName: 'wechat' | 'alipay' | 'baidu' = 'wechat'
+let platFormName: 'wechat' | 'alipay' | 'baidu' | 'toutiao' = 'wechat'
 
 /**
  * 获取各个平台的请求函数
  */
 export function getRequest (): (option: WechatMiniprogram.RequestOption) => WechatMiniprogram.RequestTask {
   switch (true) {
+    // NOTE: Feishu must come before WeChat as there is also `wx` in some environments in Feishu.
+    case typeof tt === 'object':
+      // Toutiao has 2 kinds of mini-programs: 头条小程序 and 飞书小程序. Thankfully, the interfaces
+      // of the request API are the same, but the condition might not hold true in the future.
+      platFormName = 'toutiao'
+      return tt.request.bind(tt);
     case typeof wx === 'object':
       platFormName = 'wechat'
       return wx.request.bind(wx)
@@ -81,6 +87,10 @@ export function transformError (error:any, reject, config) {
         // NetWordError
         reject(createError('Network Error', config, null, ''))
       }
+      break
+    // Can't find reference to error messages on Feishu, leave it for now.
+    case 'toutiao':
+      reject(createError('Network Error', config, null, ''))
       break
     case 'baidu':
       // TODO error.errCode

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,11 @@
-  interface MpResponse extends WechatMiniprogram.RequestSuccessCallbackResult {
-    /** 支付宝、钉钉独有 */
-    headers: WechatMiniprogram.IAnyObject,
-    status: number
-  }
+interface MpResponse extends WechatMiniprogram.RequestSuccessCallbackResult {
+  /** 支付宝、钉钉独有 */
+  headers: WechatMiniprogram.IAnyObject,
+  status: number
+}
 
-  declare let swan:  any
-  
-  declare let my:  any
+declare let swan:  any
+
+declare let my: any
+
+declare let tt: any | undefined;


### PR DESCRIPTION
# 背景

非常感謝作者(們)在這個庫上的努力。因為業務上需要支持飛書小程序，因此我們已經在自己的倉庫裡已經進行擴充了。我們也同時發這個 PR 來回饋這個倉庫，希望能為這個倉庫助一分力。

# 注意

因為飛書是頭條旗下的一個產品。目前頭條應該同時有抖音、頭條(不確定是不是同一套體系)和飛書(確定是另一套體系)的小程序。但由於兩者同樣也都暴露出 `tt` 這個 namespace且兩者 request 的 API interface 是一致的，因此我的在實踐上還是把兩著當成同一套體系。